### PR TITLE
feat: instrumentation key is on deprecation path

### DIFF
--- a/app/insights.js
+++ b/app/insights.js
@@ -1,7 +1,7 @@
 const appInsights = require('applicationinsights')
 
 function setup () {
-  if (process.env.APPINSIGHTS_INSTRUMENTATIONKEY) {
+  if (process.env.APPINSIGHTS_CONNECTION_STRING) {
     appInsights.setup().start()
     console.log('App Insights Running')
     const cloudRoleTag = appInsights.defaultClient.context.keys.cloudRole

--- a/app/insights.js
+++ b/app/insights.js
@@ -1,7 +1,7 @@
 const appInsights = require('applicationinsights')
 
 function setup () {
-  if (process.env.APPINSIGHTS_CONNECTION_STRING) {
+  if (process.env.APPLICATIONINSIGHTS_CONNECTION_STRING) {
     appInsights.setup().start()
     console.log('App Insights Running')
     const cloudRoleTag = appInsights.defaultClient.context.keys.cloudRole

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -9,7 +9,7 @@ services:
     container_name: ffc-ahwr-backoffice
     environment:
       APPINSIGHTS_CLOUDROLE: ffc-ahwr-backoffice-local
-      APPINSIGHTS_CONNECTION_STRING: ${APPINSIGHTS_CONNECTION_STRING}
+      APPLICATIONINSIGHTS_CONNECTION_STRING: ${APPLICATIONINSIGHTS_CONNECTION_STRING}
       BACKOFFICEREQUEST_QUEUE_ADDRESS: ${BACKOFFICEREQUEST_QUEUE_ADDRESS:-ffc-ahwr-backoffice-request}${MESSAGE_QUEUE_SUFFIX}
       BACKOFFICERESPONSE_QUEUE_ADDRESS: ${BACKOFFICERESPONSE_QUEUE_ADDRESS:-ffc-ahwr-backoffice-response}${MESSAGE_QUEUE_SUFFIX}
       COOKIE_PASSWORD: who-likes-cookies-i-like-cookies-everybody-likes-cookies

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -9,7 +9,7 @@ services:
     container_name: ffc-ahwr-backoffice
     environment:
       APPINSIGHTS_CLOUDROLE: ffc-ahwr-backoffice-local
-      APPINSIGHTS_INSTRUMENTATIONKEY: ${APPINSIGHTS_INSTRUMENTATIONKEY}
+      APPINSIGHTS_CONNECTION_STRING: ${APPINSIGHTS_CONNECTION_STRING}
       BACKOFFICEREQUEST_QUEUE_ADDRESS: ${BACKOFFICEREQUEST_QUEUE_ADDRESS:-ffc-ahwr-backoffice-request}${MESSAGE_QUEUE_SUFFIX}
       BACKOFFICERESPONSE_QUEUE_ADDRESS: ${BACKOFFICERESPONSE_QUEUE_ADDRESS:-ffc-ahwr-backoffice-response}${MESSAGE_QUEUE_SUFFIX}
       COOKIE_PASSWORD: who-likes-cookies-i-like-cookies-everybody-likes-cookies

--- a/helm/ffc-ahwr-backoffice/templates/container-secret.yaml
+++ b/helm/ffc-ahwr-backoffice/templates/container-secret.yaml
@@ -2,7 +2,7 @@
 {{- define "ffc-ahwr-backoffice.container-secret" -}}
 stringData:
   {{- if .Values.appInsights.connectionString }}
-  APPINSIGHTS_CONNECTION_STRING: {{ quote .Values.appInsights.connectionString }}
+  APPLICATIONINSIGHTS_CONNECTION_STRING: {{ quote .Values.appInsights.connectionString }}
   {{- end }}
   COOKIE_PASSWORD: {{ .Values.container.cookiePassword | quote }}
   REDIS_PASSWORD: {{ .Values.container.redisPassword | quote }}

--- a/helm/ffc-ahwr-backoffice/templates/container-secret.yaml
+++ b/helm/ffc-ahwr-backoffice/templates/container-secret.yaml
@@ -1,8 +1,8 @@
 {{- include "ffc-helm-library.container-secret" (list . "ffc-ahwr-backoffice.container-secret") -}}
 {{- define "ffc-ahwr-backoffice.container-secret" -}}
 stringData:
-  {{- if .Values.appInsights.key }}
-  APPINSIGHTS_INSTRUMENTATIONKEY: {{ quote .Values.appInsights.key }}
+  {{- if .Values.appInsights.connectionString }}
+  APPINSIGHTS_CONNECTION_STRING: {{ quote .Values.appInsights.connectionString }}
   {{- end }}
   COOKIE_PASSWORD: {{ .Values.container.cookiePassword | quote }}
   REDIS_PASSWORD: {{ .Values.container.redisPassword | quote }}

--- a/helm/ffc-ahwr-backoffice/values.yaml
+++ b/helm/ffc-ahwr-backoffice/values.yaml
@@ -9,7 +9,7 @@ labels: {}
 aadPodIdentity: true
 
 appInsights:
-  key:
+  connectionString:
 
 azureIdentity:
   clientID:

--- a/test/unit/app-insights.test.js
+++ b/test/unit/app-insights.test.js
@@ -22,21 +22,21 @@ describe('Application Insights', () => {
 
   const consoleLogSpy = jest.spyOn(console, 'log')
 
-  const appInsightsKey = process.env.APPINSIGHTS_CONNECTION_STRING
+  const appInsightsKey = process.env.APPLICATIONINSIGHTS_CONNECTION_STRING
 
   beforeEach(() => {
-    delete process.env.APPINSIGHTS_CONNECTION_STRING
+    delete process.env.APPLICATIONINSIGHTS_CONNECTION_STRING
     jest.clearAllMocks()
   })
 
   afterAll(() => {
-    process.env.APPINSIGHTS_CONNECTION_STRING = appInsightsKey
+    process.env.APPLICATIONINSIGHTS_CONNECTION_STRING = appInsightsKey
   })
 
   test('is started when env var exists', () => {
     const appName = 'test-app'
     process.env.APPINSIGHTS_CLOUDROLE = appName
-    process.env.APPINSIGHTS_CONNECTION_STRING = 'something'
+    process.env.APPLICATIONINSIGHTS_CONNECTION_STRING = 'something'
     const insights = require('../../app/insights')
 
     insights.setup()

--- a/test/unit/app-insights.test.js
+++ b/test/unit/app-insights.test.js
@@ -22,21 +22,21 @@ describe('Application Insights', () => {
 
   const consoleLogSpy = jest.spyOn(console, 'log')
 
-  const appInsightsKey = process.env.APPINSIGHTS_INSTRUMENTATIONKEY
+  const appInsightsKey = process.env.APPINSIGHTS_CONNECTION_STRING
 
   beforeEach(() => {
-    delete process.env.APPINSIGHTS_INSTRUMENTATIONKEY
+    delete process.env.APPINSIGHTS_CONNECTION_STRING
     jest.clearAllMocks()
   })
 
   afterAll(() => {
-    process.env.APPINSIGHTS_INSTRUMENTATIONKEY = appInsightsKey
+    process.env.APPINSIGHTS_CONNECTION_STRING = appInsightsKey
   })
 
   test('is started when env var exists', () => {
     const appName = 'test-app'
     process.env.APPINSIGHTS_CLOUDROLE = appName
-    process.env.APPINSIGHTS_INSTRUMENTATIONKEY = 'something'
+    process.env.APPINSIGHTS_CONNECTION_STRING = 'something'
     const insights = require('../../app/insights')
 
     insights.setup()


### PR DESCRIPTION
Use `APPLICATIONINSIGHTS_CONNECTION_STRING` rather than the `INSTRUMENTATION_KEY` as this is on the deprecation path. See [here](https://github.com/microsoft/ApplicationInsights-node.js#getting-started) for updated instructions.