### PR TITLE
fix(AHWR-4): create new child logger for cron job

### DIFF
--- a/app/crons/process-on-hold/scheduler.js
+++ b/app/crons/process-on-hold/scheduler.js
@@ -12,16 +12,17 @@ module.exports = {
       }, 'registering schedule for processing on hold applications and claims')
 
       cron.schedule(config.onHoldAppScheduler.schedule, async () => {
+        const logger = server.logger.child({})
         try {
           const isHoliday = await isTodayHoliday()
-          server.logger.setBindings({ isHoliday })
+          logger.setBindings({ isHoliday })
           if (!isHoliday) {
-            await processOnHoldApplications(server.logger)
-            await processOnHoldClaims(server.logger)
+            await processOnHoldApplications(logger)
+            await processOnHoldClaims(logger)
           }
-          server.logger.info('processing on hold applications and claims')
+          logger.info('processing on hold applications and claims')
         } catch (err) {
-          server.logger.error({ err }, 'processing on hold applications and claims')
+          logger.error({ err }, 'processing on hold applications and claims')
         }
       }, {
         scheduled: config.onHoldAppScheduler.enabled

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ffc-ahwr-backoffice",
-  "version": "1.24.78",
+  "version": "1.24.79",
   "description": "Back office of the health and welfare of your livestock",
   "homepage": "https://github.com/DEFRA/ffc-ahwr-backoffice",
   "main": "app/index.js",

--- a/test/unit/crons/process-on-hold-apps-scheduler.test.js
+++ b/test/unit/crons/process-on-hold-apps-scheduler.test.js
@@ -13,6 +13,7 @@ describe('Process On Hold Applications plugin test', () => {
   })
 
   test('test node cron executed', async () => {
+    const mockLogger = { info: jest.fn(), error: jest.fn(), setBindings: jest.fn() }
     process.env.ON_HOLD_APP_PROCESS_SCHEDULE = '0 18 * * 1-5'
     const mockNodeCron = require('node-cron')
     jest.mock('node-cron', () => {
@@ -23,7 +24,11 @@ describe('Process On Hold Applications plugin test', () => {
     jest.mock('../../../app/crons/process-on-hold/process')
     require('../../../app/crons/process-on-hold/process')
     const processOnHoldAppsScheduler = require('../../../app/crons/process-on-hold/scheduler')
-    const server = { logger: { info: jest.fn(), setBindings: jest.fn() } }
+    const server = {
+      logger: {
+        ...mockLogger, child: jest.fn().mockReturnValue(mockLogger)
+      }
+    }
     await processOnHoldAppsScheduler.plugin.register(server)
     expect(mockNodeCron.schedule).toHaveBeenCalledWith(
       '0 18 * * 1-5', expect.any(Function), { scheduled: true }
@@ -31,6 +36,7 @@ describe('Process On Hold Applications plugin test', () => {
   })
 
   test('Is Holiday True - test Process On Hold Applications not called', async () => {
+    const mockLogger = { info: jest.fn(), error: jest.fn(), setBindings: jest.fn() }
     const mockNodeCron = require('node-cron')
     jest.mock('node-cron', () => {
       return {
@@ -47,12 +53,17 @@ describe('Process On Hold Applications plugin test', () => {
     const { processOnHoldApplications } = require('../../../app/crons/process-on-hold/process')
     mockNodeCron.schedule.mockImplementationOnce(async (frequency, callback) => await callback())
     const processOnHoldAppsScheduler = require('../../../app/crons/process-on-hold/scheduler')
-    const server = { logger: { info: jest.fn(), setBindings: jest.fn() } }
+    const server = {
+      logger: {
+        ...mockLogger, child: jest.fn().mockReturnValue(mockLogger)
+      }
+    }
     await processOnHoldAppsScheduler.plugin.register(server)
     expect(processOnHoldApplications).toBeCalledTimes(0)
   })
 
   test('Is Holiday Throw Error - test Process On Hold Applications not called', async () => {
+    const mockLogger = { info: jest.fn(), error: jest.fn(), setBindings: jest.fn() }
     const mockNodeCron = require('node-cron')
     jest.mock('node-cron', () => {
       return {
@@ -69,12 +80,17 @@ describe('Process On Hold Applications plugin test', () => {
     const { processOnHoldApplications } = require('../../../app/crons/process-on-hold/process')
     mockNodeCron.schedule.mockImplementationOnce(async (frequency, callback) => await callback())
     const processOnHoldAppsScheduler = require('../../../app/crons/process-on-hold/scheduler')
-    const server = { logger: { error: jest.fn(), info: jest.fn() } }
+    const server = {
+      logger: {
+        ...mockLogger, child: jest.fn().mockReturnValue(mockLogger)
+      }
+    }
     await processOnHoldAppsScheduler.plugin.register(server)
     expect(processOnHoldApplications).toBeCalledTimes(0)
   })
 
   test('test Process On Hold Applications called', async () => {
+    const mockLogger = { info: jest.fn(), error: jest.fn(), setBindings: jest.fn() }
     const mockNodeCron = require('node-cron')
     jest.mock('node-cron', () => {
       return {
@@ -94,7 +110,11 @@ describe('Process On Hold Applications plugin test', () => {
 
     mockNodeCron.schedule.mockImplementationOnce(async (_, callback) => await callback())
     const processOnHoldAppsScheduler = require('../../../app/crons/process-on-hold/scheduler')
-    const server = { logger: { info: jest.fn(), setBindings: jest.fn() } }
+    const server = {
+      logger: {
+        ...mockLogger, child: jest.fn().mockReturnValue(mockLogger)
+      }
+    }
     await processOnHoldAppsScheduler.plugin.register(server)
 
     expect(processOnHoldApplications).toHaveBeenCalled()

--- a/test/unit/crons/process-on-hold-apps.test.js
+++ b/test/unit/crons/process-on-hold-apps.test.js
@@ -64,8 +64,8 @@ describe('Process process on hold applications function test.', () => {
       total: 1
     })
     const { processOnHoldApplications } = require('../../../app/crons/process-on-hold/process')
-    const server = { setBindings: jest.fn() }
-    await processOnHoldApplications(server)
+    const logger = { setBindings: jest.fn() }
+    await processOnHoldApplications(logger)
 
     expect(getApplications).toHaveBeenCalled()
     expect(processApplicationClaim).toHaveBeenCalled()
@@ -80,8 +80,8 @@ describe('Process process on hold applications function test.', () => {
       total: 1
     })
     const { processOnHoldApplications } = require('../../../app/crons/process-on-hold/process')
-    const server = { setBindings: jest.fn() }
-    await processOnHoldApplications(server)
+    const logger = { setBindings: jest.fn() }
+    await processOnHoldApplications(logger)
 
     expect(getApplications).toHaveBeenCalled()
     expect(processApplicationClaim).not.toHaveBeenCalled()

--- a/test/unit/crons/process-on-hold-claims.test.js
+++ b/test/unit/crons/process-on-hold-claims.test.js
@@ -48,8 +48,8 @@ describe('Process process on hold claims function test.', () => {
       applications: [],
       total: 0
     })
-    const server = { setBindings: jest.fn() }
-    await processOnHoldClaims(server)
+    const logger = { setBindings: jest.fn() }
+    await processOnHoldClaims(logger)
 
     expect(getClaims).toHaveBeenCalled()
     expect(updateClaimStatus).not.toHaveBeenCalled()
@@ -64,8 +64,8 @@ describe('Process process on hold claims function test.', () => {
       total: 1
     })
     const { processOnHoldClaims } = require('../../../app/crons/process-on-hold/process')
-    const server = { setBindings: jest.fn() }
-    await processOnHoldClaims(server)
+    const logger = { setBindings: jest.fn() }
+    await processOnHoldClaims(logger)
 
     expect(getClaims).toHaveBeenCalled()
     expect(updateClaimStatus).toHaveBeenCalled()


### PR DESCRIPTION
Using server.logger for the cron job meant than any bindings were being kept and the added to the request logger each time it was created.

Creating a new child logger for each instance of the job should fix this.

For testing you may want to update ON_HOLD_APP_PROCESS_SCHEDULE to something more regular [node-cron](https://www.npmjs.com/package/node-cron) is the library we are using so setting the schedule as `'* * * * *'` will trigger it every minute.