### PR TITLE
fix: msal-node library version moved to 1.14.5

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -5,6 +5,6 @@ ignore:
     SNYK-JS-AZUREMSALNODE-7246761:
         - "*":
             reason: None given
-            expires: "2024-12-01T00:00:00.000Z"
-            created: "2024-07-26T00:00:00.000Z"
+            expires: "2025-03-01T00:00:00.000Z"
+            created: "2024-12-12T00:00:00.000Z"
 patch: {}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "ffc-ahwr-backoffice",
-  "version": "1.24.77",
+  "version": "1.24.79",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ffc-ahwr-backoffice",
-      "version": "1.24.77",
+      "version": "1.24.79",
       "license": "OGL-UK-3.0",
       "dependencies": {
-        "@azure/msal-node": "2.9.2",
+        "@azure/msal-node": "1.14.5",
         "@hapi/boom": "10.00",
         "@hapi/catbox-redis": "^6.0.2",
         "@hapi/cookie": "^11.0.2",
@@ -148,24 +148,25 @@
       }
     },
     "node_modules/@azure/msal-common": {
-      "version": "14.12.0",
-      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-14.12.0.tgz",
-      "integrity": "sha512-IDDXmzfdwmDkv4SSmMEyAniJf6fDu3FJ7ncOjlxkDuT85uSnLEhZi3fGZpoR7T4XZpOMx9teM9GXBgrfJgyeBw==",
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-9.1.1.tgz",
+      "integrity": "sha512-we9xR8lvu47fF0h+J8KyXoRy9+G/fPzm3QEa2TrdR3jaVS3LKAyE2qyMuUkNdbVkvzl8Zr9f7l+IUSP22HeqXw==",
       "engines": {
         "node": ">=0.8.0"
       }
     },
     "node_modules/@azure/msal-node": {
-      "version": "2.9.2",
-      "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-2.9.2.tgz",
-      "integrity": "sha512-8tvi6Cos3m+0KmRbPjgkySXi+UQU/QiuVRFnrxIwt5xZlEEFa69O04RTaNESGgImyBBlYbo2mfE8/U8Bbdk1WQ==",
+      "version": "1.14.5",
+      "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-1.14.5.tgz",
+      "integrity": "sha512-NcVdMfn8Z3ogN+9RjOSF7uwf2Gki5DEJl0BdDSL83KUAgVAobtkZi5W8EqxbJLrTO/ET0jv5DregrcR5qg2pEA==",
+      "deprecated": "A newer major version of this library is available. Please upgrade to the latest available version.",
       "dependencies": {
-        "@azure/msal-common": "14.12.0",
-        "jsonwebtoken": "^9.0.0",
+        "@azure/msal-common": "^9.0.1",
+        "jsonwebtoken": "^8.5.1",
         "uuid": "^8.3.0"
       },
       "engines": {
-        "node": ">=16"
+        "node": "10 || 12 || 14 || 16 || 18"
       }
     },
     "node_modules/@azure/opentelemetry-instrumentation-azure-sdk": {
@@ -14215,9 +14216,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.7",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
-      "integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==",
+      "version": "3.3.8",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.8.tgz",
+      "integrity": "sha512-WNLf5Sd8oZxOm+TzppcYk8gVOgP+l58xNy58D0nbUnOxOWRWvlcCV4kUF7ltmI6PsrLl/BgKEyS4mqsGChFN0w==",
       "dev": true,
       "funding": [
         {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   ],
   "license": "OGL-UK-3.0",
   "dependencies": {
-    "@azure/msal-node": "2.9.2",
+    "@azure/msal-node": "1.14.5",
     "@hapi/boom": "10.00",
     "@hapi/catbox-redis": "^6.0.2",
     "@hapi/cookie": "^11.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ffc-ahwr-backoffice",
-  "version": "1.24.79",
+  "version": "1.24.80",
   "description": "Back office of the health and welfare of your livestock",
   "homepage": "https://github.com/DEFRA/ffc-ahwr-backoffice",
   "main": "app/index.js",


### PR DESCRIPTION
msal-node library version moved to 1.14.5 and added 3 months onto the Snyk ignore rule.