### PR TITLE
fix(AHWR-457): fix claim status updates

### DIFF
--- a/__mocks__/applicationinsights.js
+++ b/__mocks__/applicationinsights.js
@@ -1,0 +1,8 @@
+const appInsights = {
+  defaultClient: {
+    trackEvent: jest.fn(),
+    trackException: jest.fn()
+  }
+}
+
+module.exports = appInsights

--- a/app/api/claims.js
+++ b/app/api/claims.js
@@ -12,11 +12,12 @@ async function getClaim (reference, logger) {
   }
 }
 
-async function getClaims (searchType, searchText, limit, offset, sort, logger) {
+async function getClaims (searchType, searchText, filter, limit, offset, sort, logger) {
   const endpoint = `${applicationApiUri}/claim/search`
   const options = {
     payload: {
       search: { text: searchText, type: searchType },
+      filter,
       limit,
       offset,
       sort

--- a/app/crons/process-on-hold/process.js
+++ b/app/crons/process-on-hold/process.js
@@ -4,32 +4,58 @@ const { status } = require('../../../app/constants/status')
 
 const getCommonData = () => {
   const now = new Date()
-  return { searchType: 'status', searchText: 'ON HOLD', datePast24Hrs: now.setDate(now.getDate() - 1) }
+  return { searchType: 'status', searchText: 'ON HOLD', date24HrsAgo: now.setDate(now.getDate() - 1) }
+}
+const formatDateForFilter = (timestamp) => {
+  const dateString = new Date(timestamp)
+    .toLocaleString('en-GB')
+  const [date, time] = dateString.split(',')
+  const bigEndianDate = date.split('/').reverse().join('-')
+
+  return `${bigEndianDate}${time}`
 }
 
 const processOnHoldApplications = async (logger) => {
-  const { searchType, searchText, datePast24Hrs } = getCommonData()
+  const { searchType, searchText, date24HrsAgo } = getCommonData()
   const apps = await getApplications(searchType, searchText, 9999, 0, [], { field: 'CREATEDAT', direction: 'ASC' }, logger)
   logger.setBindings({ applicationsTotal: apps.total })
-  if (apps.total > 0) {
-    const applicationRefs = apps.applications.filter(a => new Date(a.updatedAt) <= datePast24Hrs).map(a => a.reference)
-    logger.setBindings({ applicationRefs })
-    for (const appRef of applicationRefs) {
+  const applicationRefs = apps.applications.filter(a => new Date(a.updatedAt) <= date24HrsAgo).map(a => a.reference)
+  const failedApplicationRefs = []
+  for (const appRef of applicationRefs) {
+    try {
       await processApplicationClaim(appRef, 'admin', true, logger)
+    } catch (_) {
+      failedApplicationRefs.push(appRef)
     }
   }
+
+  logger.setBindings({ applicationRefs, failedApplicationRefs })
 }
+
 const processOnHoldClaims = async (logger) => {
-  const { searchType, searchText, datePast24Hrs } = getCommonData()
-  const { claims, total } = await getClaims(searchType, searchText)
+  const { searchType, searchText, date24HrsAgo } = getCommonData()
+  const value = formatDateForFilter(date24HrsAgo)
+  const filter = {
+    field: 'updatedAt',
+    op: 'lte',
+    value
+  }
+  const limit = 500
+  const { claims, total } = await getClaims(searchType, searchText, filter, limit, undefined, undefined, logger)
   logger.setBindings({ claimsTotal: total })
-  if (total > 0) {
-    const claimRefs = claims.filter(a => new Date(a.updatedAt) <= datePast24Hrs).map(a => a.reference)
-    logger.setBindings({ claimRefs })
-    for (const claimRef of claimRefs) {
-      await updateClaimStatus(claimRef, 'admin', status.READY_TO_PAY, logger)
+
+  const claimRefs = []
+  const failedClaimRefs = []
+  for (const { reference } of claims) {
+    try {
+      await updateClaimStatus(reference, 'admin', status.READY_TO_PAY, logger)
+      claimRefs.push(reference)
+    } catch (_) {
+      failedClaimRefs.push(reference)
     }
   }
+
+  logger.setBindings({ claimRefs, failedClaimRefs })
 }
 
 module.exports = {

--- a/app/routes/models/claim-list.js
+++ b/app/routes/models/claim-list.js
@@ -70,7 +70,8 @@ async function createModel (request, page, pageLimit, customSearch) {
   const { limit, offset } = getPagination(page, pageLimit)
   const { searchText, searchType } = customSearch?.searchText ? customSearch : checkValidSearch(getClaimSearch(request, claimSearch.searchText))
   const sortField = getClaimSearch(request, claimSearch.sort) ?? undefined
-  const claimsData = await getClaims(searchType, searchText, limit, offset, sortField, request.logger)
+  const filter = undefined
+  const claimsData = await getClaims(searchType, searchText, filter, limit, offset, sortField, request.logger)
   let claims = []
   if (claimsData.total > 0) {
     claims = claimsData.claims.map((claim) => [

--- a/app/server.js
+++ b/app/server.js
@@ -71,10 +71,6 @@ async function createServer () {
     }
   })
 
-  if (config.isDev) {
-    await server.register(require('blipp'))
-  }
-
   await server.register(onHoldAppScheduler)
 
   return server

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,6 @@
       },
       "devDependencies": {
         "@hapi/catbox-memory": "^5.0.1",
-        "blipp": "^4.0.2",
         "cheerio": "^1.0.0-rc.10",
         "clean-webpack-plugin": "^4.0.0",
         "css-loader": "^6.6.0",
@@ -3493,26 +3492,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/blipp": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/blipp/-/blipp-4.0.2.tgz",
-      "integrity": "sha512-QA5amT0IFJgCFgJeWw2udD2zZLui60NgqXTyvbSq+qpVbS6jfqELTRlC8PWW0yD4+chdZ2a+svnN6WE9zqfK5Q==",
-      "dev": true,
-      "license": "BSD",
-      "dependencies": {
-        "@hapi/hoek": "9.x.x",
-        "chalk": "4.x.x",
-        "easy-table": "1.x.x",
-        "joi": "17.x.x"
-      }
-    },
-    "node_modules/blipp/node_modules/@hapi/hoek": {
-      "version": "9.3.0",
-      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
-      "integrity": "sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ==",
-      "dev": true,
-      "license": "BSD-3-Clause"
-    },
     "node_modules/boolbase": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
@@ -3898,17 +3877,6 @@
         "node": ">=12"
       }
     },
-    "node_modules/clone": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
-      "integrity": "sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
     "node_modules/clone-deep": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/clone-deep/-/clone-deep-4.0.1.tgz",
@@ -4264,20 +4232,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/defaults": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.4.tgz",
-      "integrity": "sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "clone": "^1.0.2"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/define-data-property": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
@@ -4513,19 +4467,6 @@
       },
       "engines": {
         "node": ">= 0.4"
-      }
-    },
-    "node_modules/easy-table": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/easy-table/-/easy-table-1.2.0.tgz",
-      "integrity": "sha512-OFzVOv03YpvtcWGe5AayU5G2hgybsg3iqA6drU8UaoZyB9jLGMTrz9+asnLp/E+6qPh88yEI1gvyZFZ41dmgww==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "optionalDependencies": {
-        "wcwidth": "^1.0.1"
       }
     },
     "node_modules/ecdsa-sig-formatter": {
@@ -11575,17 +11516,6 @@
       },
       "engines": {
         "node": ">=10.13.0"
-      }
-    },
-    "node_modules/wcwidth": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
-      "integrity": "sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "defaults": "^1.0.3"
       }
     },
     "node_modules/webpack": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ffc-ahwr-backoffice",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ffc-ahwr-backoffice",
-      "version": "2.0.4",
+      "version": "2.0.5",
       "license": "OGL-UK-3.0",
       "dependencies": {
         "@azure/msal-node": "1.14.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ffc-ahwr-backoffice",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "description": "Back office of the health and welfare of your livestock",
   "homepage": "https://github.com/DEFRA/ffc-ahwr-backoffice",
   "main": "app/index.js",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
   },
   "devDependencies": {
     "@hapi/catbox-memory": "^5.0.1",
-    "blipp": "^4.0.2",
     "cheerio": "^1.0.0-rc.10",
     "clean-webpack-plugin": "^4.0.0",
     "css-loader": "^6.6.0",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "test:debug": "node --inspect-brk=0.0.0.0 ./node_modules/jest/bin/jest.js --coverage=false --onlyChanged --watch --runInBand --no-cache",
     "start:watch": "npm run build:watch & npm run start:nodemon",
     "start:debug": "nodemon --inspect-brk=0.0.0.0 --ext css,js,njk --legacy-watch app/index.js",
-    "start:nodemon": "nodemon --inspect=0.0.0.0 --ext css,js,njk --legacy-watch app/index.js"
+    "start:nodemon": "nodemon --inspect=0.0.0.0 --ext css,js,njk --legacy-watch app/index.js",
+    "jest": "jest"
   },
   "author": "Defra",
   "license": "OGL-UK-3.0",

--- a/test/teardown.js
+++ b/test/teardown.js
@@ -2,5 +2,4 @@ afterEach(async () => {
   if (global.__SERVER__) {
     await global.__SERVER__.stop()
   }
-  require('applicationinsights').dispose()
 })

--- a/test/unit/api/claim.test.js
+++ b/test/unit/api/claim.test.js
@@ -68,8 +68,9 @@ describe('Claims API', () => {
     wreck.post = jest.fn().mockRejectedValueOnce(wreckResponse)
 
     const logger = { setBindings: jest.fn() }
+    const filter = { field: 'updatedAt', op: 'lte', value: '2025-01-17' }
     expect(async () => {
-      await getClaims('sbi', '1010', 10, 10, 'ASC', logger)
+      await getClaims('sbi', '1010', filter, 10, 10, 'ASC', logger)
     }).rejects.toEqual(wreckResponse)
   })
 


### PR DESCRIPTION
* pass date filter to claims search
* increase results limit to 500
* capture individually failing updates
* trigger app insights if any updates fail

**testing:**
To test you will need some applications or claims that have `updatedAt` dates of more than 24 hours ago and a statusId of 11 (on hold).

**cron scheduling:**
The job is scheduled to run once an hour, if you want to increase the frequency you can change the value of `ON_HOLD_APP_PROCESS_SCHEDULE`. `* * * * *` will run it once per minute, if you want even shorter intervals you can do something like `*/20 * * * * *` for once every 20 seconds.