### PR TITLE
fix(AHWR-29): restrict width of notes column

### DIFF
--- a/app/routes/models/application-history.js
+++ b/app/routes/models/application-history.js
@@ -52,7 +52,7 @@ const gethistoryTableHeader = () => {
     { text: "Time" },
     { text: "Action" },
     { text: "User" },
-    { text: "Note" },
+    { text: "Note", classes: 'govuk-!-width-one-quarter' },
   ];
 };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ffc-ahwr-backoffice",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ffc-ahwr-backoffice",
-      "version": "2.2.0",
+      "version": "2.2.1",
       "license": "OGL-UK-3.0",
       "dependencies": {
         "@azure/msal-node": "1.14.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ffc-ahwr-backoffice",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "Back office of the health and welfare of your livestock",
   "homepage": "https://github.com/DEFRA/ffc-ahwr-backoffice",
   "main": "app/index.js",


### PR DESCRIPTION
Addresses issue raised in QA of AHWR-29, history layout for long notes.

**Claim before:**
<img width="1735" alt="Screenshot 2025-03-18 at 9 32 51 am" src="https://github.com/user-attachments/assets/f5194c4c-c6b7-4741-9aec-5ffb4061ec4f" />

**Claim after:**
<img width="1735" alt="Screenshot 2025-03-18 at 10 35 58 am" src="https://github.com/user-attachments/assets/a39a58e8-bcb1-4779-8cb8-58fee6cb73d4" />

**Application before:**
<img width="1156" alt="Screenshot 2025-03-18 at 10 37 18 am" src="https://github.com/user-attachments/assets/b30b6ce2-2300-4888-9a3d-44d21898b71f" />

**Application after:**
<img width="1178" alt="Screenshot 2025-03-18 at 10 31 29 am" src="https://github.com/user-attachments/assets/8dc96116-25b4-4b54-adcd-cf24ec8ec755" />

