### PR TITLE
fix(AHWR-690): Prevent Pay/Reject buttons appearing unless other user…

### DIFF
--- a/app/routes/claims-data.js
+++ b/app/routes/claims-data.js
@@ -64,16 +64,23 @@ module.exports = [
               })
               .messages({
                 "number.base": "Enter year",
-                "number.min": "Enter valid year",
-                "number.max": "Enter valid year",
+                "number.min": "Enter valid year between 2020 and 2030",
+                "number.max": "Enter valid year between 2020 and 2030",
               }),
-            vetRCVSNumber: joi.alternatives().conditional("form", {
-              is: "updateVetRCVSNumber",
-              then: joi
-                .string()
-                .pattern(/^\d{6}[\dX]$/i)
-                .required(),
-            }),
+            vetRCVSNumber: joi
+              .alternatives()
+              .conditional("form", {
+                is: "updateVetRCVSNumber",
+                then: joi
+                  .string()
+                  .pattern(/^\d{6}[\dX]$/i)
+                  .required(),
+              })
+              .messages({
+                "string.empty": "Enter Vet's RCVS number",
+                "string.pattern.base":
+                  "Vet's RCVS number should be a 7 digit number or 6 digit number ending with a letter",
+              }),
             note: joi.string().required().messages({
               "any.required": "Enter note",
               "string.empty": "Enter note",

--- a/app/routes/utils/get-claim-view-states.js
+++ b/app/routes/utils/get-claim-view-states.js
@@ -59,29 +59,25 @@ const getClaimViewStates = (request, statusId, currentStatusEvent) => {
     (isAdministrator || isAuthoriser) &&
     statusId === status.RECOMMENDED_TO_PAY &&
     approve === false &&
-    currentStatusEvent &&
-    name !== currentStatusEvent.ChangedBy;
+    statusWasSetByAnotherUser(currentStatusEvent, name);
 
   const authoriseForm =
     (isAdministrator || isAuthoriser) &&
     statusId === status.RECOMMENDED_TO_PAY &&
     approve === true &&
-    currentStatusEvent &&
-    name !== currentStatusEvent.ChangedBy;
+    statusWasSetByAnotherUser(currentStatusEvent, name);
 
   const rejectAction =
     (isAdministrator || isAuthoriser) &&
     statusId === status.RECOMMENDED_TO_REJECT &&
     reject === false &&
-    currentStatusEvent &&
-    name !== currentStatusEvent.ChangedBy;
+    statusWasSetByAnotherUser(currentStatusEvent, name);
 
   const rejectForm =
     (isAdministrator || isAuthoriser) &&
     statusId === status.RECOMMENDED_TO_REJECT &&
     reject === true &&
-    currentStatusEvent &&
-    name !== currentStatusEvent.ChangedBy;
+    statusWasSetByAnotherUser(currentStatusEvent, name);
 
   const {
     updateStatusAction,
@@ -122,6 +118,10 @@ const getClaimViewStates = (request, statusId, currentStatusEvent) => {
     updateDateOfVisitAction,
     updateDateOfVisitForm,
   };
+};
+
+const statusWasSetByAnotherUser = (currentStatusEvent, name) => {
+  return currentStatusEvent && name !== currentStatusEvent.updatedBy;
 };
 
 const superAdminActions = (

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ffc-ahwr-backoffice",
-  "version": "2.3.3",
+  "version": "2.3.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ffc-ahwr-backoffice",
-      "version": "2.3.3",
+      "version": "2.3.4",
       "license": "OGL-UK-3.0",
       "dependencies": {
         "@azure/msal-node": "1.14.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ffc-ahwr-backoffice",
-  "version": "2.3.3",
+  "version": "2.3.4",
   "description": "Back office of the health and welfare of your livestock",
   "homepage": "https://github.com/DEFRA/ffc-ahwr-backoffice",
   "main": "app/index.js",

--- a/scripts/test
+++ b/scripts/test
@@ -68,6 +68,7 @@ compose() {
 
   if [ "${fix_lint}" = "true" ]; then
     npm run lint:fix
+    npm run prettier:fix
   fi
 
   # Guarantee clean environment

--- a/test/unit/routes/utils/get-claim-view-states.test.js
+++ b/test/unit/routes/utils/get-claim-view-states.test.js
@@ -869,7 +869,7 @@ test("status: in recommended to pay, user: admin, recommender: different person"
     },
   };
   const currentStatusEvent = {
-    ChangedBy: "someone else",
+    updatedBy: "someone else",
   };
   const state = getClaimViewStates(
     request,
@@ -914,7 +914,7 @@ test("status: in recommended to pay, user: admin, recommender: same person", () 
     },
   };
   const currentStatusEvent = {
-    ChangedBy: currentUser,
+    updatedBy: currentUser,
   };
   const state = getClaimViewStates(
     request,
@@ -959,7 +959,7 @@ test("status: in recommended to pay, user: recommender, recommender: different p
     },
   };
   const currentStatusEvent = {
-    ChangedBy: "someone else",
+    updatedBy: "someone else",
   };
   const state = getClaimViewStates(
     request,
@@ -1004,7 +1004,7 @@ test("status: in recommended to pay, user: authoriser, recommender: different pe
     },
   };
   const currentStatusEvent = {
-    ChangedBy: "someone else",
+    updatedBy: "someone else",
   };
   const state = getClaimViewStates(
     request,
@@ -1049,7 +1049,7 @@ test("status: in recommended to pay, query: approve, user: admin, recommender: d
     },
   };
   const currentStatusEvent = {
-    ChangedBy: "someone else",
+    updatedBy: "someone else",
   };
   const state = getClaimViewStates(
     request,
@@ -1094,7 +1094,7 @@ test("status: in recommended to pay, query: approve, user: recommender, recommen
     },
   };
   const currentStatusEvent = {
-    ChangedBy: "someone else",
+    updatedBy: "someone else",
   };
   const state = getClaimViewStates(
     request,
@@ -1139,7 +1139,7 @@ test("status: in recommended to pay, query: approve, user: authoriser, recommend
     },
   };
   const currentStatusEvent = {
-    ChangedBy: "someone else",
+    updatedBy: "someone else",
   };
   const state = getClaimViewStates(
     request,
@@ -1184,7 +1184,7 @@ test("status: in recommended to reject, user: admin, recommender: different pers
     },
   };
   const currentStatusEvent = {
-    ChangedBy: "someone else",
+    updatedBy: "someone else",
   };
   const state = getClaimViewStates(
     request,
@@ -1229,7 +1229,7 @@ test("status: in recommended to reject, user: admin, recommender: same person", 
     },
   };
   const currentStatusEvent = {
-    ChangedBy: currentUser,
+    updatedBy: currentUser,
   };
   const state = getClaimViewStates(
     request,
@@ -1274,7 +1274,7 @@ test("status: in recommended to reject, user: recommender, recommender: differen
     },
   };
   const currentStatusEvent = {
-    ChangedBy: "someone else",
+    updatedBy: "someone else",
   };
   const state = getClaimViewStates(
     request,
@@ -1319,7 +1319,7 @@ test("status: in recommended to reject, user: authoriser, recommender: different
     },
   };
   const currentStatusEvent = {
-    ChangedBy: "someone else",
+    updatedBy: "someone else",
   };
   const state = getClaimViewStates(
     request,
@@ -1364,7 +1364,7 @@ test("status: in recommended to reject, query: reject, user: admin, recommender:
     },
   };
   const currentStatusEvent = {
-    ChangedBy: "someone else",
+    updatedBy: "someone else",
   };
   const state = getClaimViewStates(
     request,
@@ -1409,7 +1409,7 @@ test("status: in recommended to reject, query: reject, user: admin, recommender:
     },
   };
   const currentStatusEvent = {
-    ChangedBy: currentUser,
+    updatedBy: currentUser,
   };
   const state = getClaimViewStates(
     request,
@@ -1454,7 +1454,7 @@ test("status: in recommended to reject, query: reject, user: recommender, recomm
     },
   };
   const currentStatusEvent = {
-    ChangedBy: "someone else",
+    updatedBy: "someone else",
   };
   const state = getClaimViewStates(
     request,
@@ -1499,7 +1499,7 @@ test("status: in recommended to reject, query: reject, user: authoriser, recomme
     },
   };
   const currentStatusEvent = {
-    ChangedBy: "someone else",
+    updatedBy: "someone else",
   };
   const state = getClaimViewStates(
     request,


### PR DESCRIPTION
… moved to recommend.

The value coming back from application API will have field called updatedBy, which is what we should be checking against. See screenshot here for code that constructs the response in application:

<img width="643" alt="Screenshot 2025-04-07 at 21 07 20" src="https://github.com/user-attachments/assets/fd2a3230-750f-4e66-8c6c-6d0826eaa2ad" />

Also updated a couple of error messages shown on the data forms to be more human friendly. The date of visit has to have ayear between 2020 and 2030, so indicate that. The RCVS number now explains in English rather than spitting out the regex pattern