### PR TITLE
fix(no-jira): Tidy up fixes pre-MH dev

### DIFF
--- a/app/lib/search-validation.js
+++ b/app/lib/search-validation.js
@@ -27,7 +27,7 @@ const validStatus = [
   "hold",
   "on hold",
 ];
-const sbiRegEx = /^[\0-9]{9}$/i;
+const sbiRegEx = /^[0-9]{9}$/i;
 const validTypes = ["review", "endemics"];
 const validSpecies = (searchText) => {
   const species = {

--- a/app/routes/claims-data.js
+++ b/app/routes/claims-data.js
@@ -30,10 +30,16 @@ module.exports = [
               .string()
               .valid("claim", "agreement")
               .required(),
-            vetsName: joi.alternatives().conditional("form", {
-              is: "updateVetsName",
-              then: joi.string().required(),
-            }),
+            vetsName: joi
+              .alternatives()
+              .conditional("form", {
+                is: "updateVetsName",
+                then: joi.string().required(),
+              })
+              .messages({
+                "any.required": "Enter vet's name",
+                "string.empty": "Enter vet's name",
+              }),
             day: joi
               .alternatives()
               .conditional("form", {

--- a/app/routes/view-agreement.js
+++ b/app/routes/view-agreement.js
@@ -188,7 +188,6 @@ module.exports = {
         applicationDetails,
         historyDetails,
         applicationClaimDetails,
-        contactPerson: currentStatusEvent?.ChangedBy,
         withdrawAction,
         withdrawForm,
         moveToInCheckAction,

--- a/app/routes/view-claim.js
+++ b/app/routes/view-claim.js
@@ -210,7 +210,7 @@ module.exports = {
       const getAction = (query, visuallyHiddenText, id) => ({
         items: [
           {
-            href: `/view-claim/${reference}?${query}=true&page=${page}#${id}`,
+            href: `/view-claim/${reference}?${query}=true&page=${page}&returnPage=${returnPage}#${id}`,
             text: "Change",
             visuallyHiddenText,
           },
@@ -477,9 +477,7 @@ module.exports = {
         claimOrAgreement: "claim",
         title: upperFirstLetter(application.data.organisation.name),
         claimSummaryDetails: rowsWithData,
-        contactPerson: currentStatusEvent?.ChangedBy,
         status: {
-          capitalisedtype: formatStatusId(claim.statusId),
           normalType: upperFirstLetter(
             formatStatusId(claim.statusId).toLowerCase(),
           ),

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ffc-ahwr-backoffice",
-  "version": "2.3.4",
+  "version": "2.3.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ffc-ahwr-backoffice",
-      "version": "2.3.4",
+      "version": "2.3.5",
       "license": "OGL-UK-3.0",
       "dependencies": {
         "@azure/msal-node": "1.14.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ffc-ahwr-backoffice",
-  "version": "2.3.4",
+  "version": "2.3.5",
   "description": "Back office of the health and welfare of your livestock",
   "homepage": "https://github.com/DEFRA/ffc-ahwr-backoffice",
   "main": "app/index.js",

--- a/test/lib/search-validation.test.js
+++ b/test/lib/search-validation.test.js
@@ -1,6 +1,6 @@
 const setSearchParams = require("../../app/lib/search-validation");
 
-describe("Set sesrch params test", () => {
+describe("Set search params test", () => {
   test.each([
     { type: "ref", text: "AHWR-5446-5EF4" },
     { type: "ref", text: "IAHW-1234-5678" },

--- a/test/unit/routes/utils/regex-checker.test.js
+++ b/test/unit/routes/utils/regex-checker.test.js
@@ -13,12 +13,6 @@ describe("regexChecker", () => {
     const result = regexChecker(regex, str);
     expect(result).toBe(true);
   });
-  test("should return true if the string matches the regex", () => {
-    const regex = /^AHWR-[A-Z0-9]{4}-[A-Z0-9]{4}$/i;
-    const str = "AHWR-1234-5678";
-    const result = regexChecker(regex, str);
-    expect(result).toBe(true);
-  });
 
   test("should return false if the string does not match the regex", () => {
     const regex = /^AHWR-[\da-f]{4}-[\da-f]{4}$/i;
@@ -27,17 +21,10 @@ describe("regexChecker", () => {
     expect(result).toBe(false);
   });
 
-  test("should handle invalid regex", () => {
+  test("should handle invalid regex and return false", () => {
     const regex = "[";
     const str = "12345";
     const result = regexChecker(regex, str);
     expect(result).toBe(false);
-  });
-  test("should show error if regex is invalid", () => {
-    const regex = "[";
-    const str = "12345";
-    regexChecker(regex, str);
-
-    expect(regexChecker(regex, str)).toBe(false);
   });
 });


### PR DESCRIPTION
* Fix return page applied to back button after data update actioned
* Display nicer error message if user enters no vet's name on update form
* Fix bogus sbi regex which was checking the range null character to 9
* Remove unused and incorrect property passed into views
* Remove a couple of redundant tests