### PR TITLE
Update sonar-project.properties to include nodejs.executable

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -2,3 +2,4 @@ sonar.javascript.exclusions=**/jest.config.js,**/__mocks__/**,**/node_modules/**
 sonar.cpd.exclusions=**/*
 sonar.javascript.lcov.reportPaths=test-output/lcov.info
 sonar.exclusions=/test/**,**/*.test.js,*snyk_report.html,*snyk_report.css
+sonar.nodejs.executable=/usr/local/bin/node


### PR DESCRIPTION
The embedded Node.js runtime is failing. Updating the sonarcloud config to use a stable, supported Node.js version from the build agent host and explicitly tell the scanner to use it.

There are some examples of this already being used across the DEFRA repo. 
https://github.com/search?q=org%3ADEFRA%20sonar.nodejs.executable&type=code


```
17:39:27  16:39:26.970 ERROR: Error relocating /root/.sonar/js/node-runtime/node: _ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE15_M_replace_coldEPcmPKcmm: symbol not found
17:39:27  16:39:26.975 WARN: Embedded Node.js failed to deploy in /root/.sonar.
17:39:27  You can change the location by setting the option `sonar.userHome` or the environment variable `SONAR_USER_HOME`.
17:39:27  Otherwise, it will default to /root/.sonar/js/node-runtime.
17:39:27  Will fallback to host Node.js.
17:39:27  org.sonar.plugins.javascript.nodejs.NodeCommandException: Failed to determine the version of Node.js, exit value 127. Executed: '/root/.sonar/js/node-runtime/node -v
```